### PR TITLE
Passing the correct password value to Credentials.basic

### DIFF
--- a/src/main/java/com/github/cjmatta/kafka/connect/sse/ServerSentEventClient.java
+++ b/src/main/java/com/github/cjmatta/kafka/connect/sse/ServerSentEventClient.java
@@ -69,7 +69,7 @@ public class ServerSentEventClient implements EventHandler {
           if (response.request().header("Authorization") != null) {
             return null; // Give up, we've already failed to authenticate.
           }
-          String credential = Credentials.basic(username, password.toString());
+          String credential = Credentials.basic(username, password.value());
           return response.request().newBuilder()
             .header("Authorization", credential)
             .build();


### PR DESCRIPTION
Requests were returning 401 due to the `[Hidden]` string being passed instead of the correct value.